### PR TITLE
Reduce stack-allocated array size

### DIFF
--- a/src/spartan-edge-esp32-boot.cpp
+++ b/src/spartan-edge-esp32-boot.cpp
@@ -48,7 +48,7 @@ void spartan_edge_esp32_boot::xfpgaGPIOInit(void) {
 
 // loading the FPGA LOGIC
 int spartan_edge_esp32_boot::xlibsSstream(const char* path) {
-  unsigned char byte_buff[1024];
+  unsigned char byte_buff[READ_SIZE];
   int byte_len;
   unsigned byte;
   int i = 0;


### PR DESCRIPTION
This fixes an abort after programming the FPGA that results in an infinite
reset loop of the board.  The call stack depth must be close enough to
the 8K maximum that the 1024-byte array was enough to overflow it, but
a 256-byte array is fine.  I suspect the remainder is being used up
by the SD_MMC calls, but I haven't investigated further.